### PR TITLE
Update to use upstream image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,38 +26,22 @@ RUN apt update -qqy \
 	  unzip \
  && rm -rf /var/lib/apt/lists/*
 
-# -- Install security tools
+# -- Install security tools in TOOLS_DIR
 ENV SPOTBUGS_VERSION=3.1.11
 ENV DEPCHECK_VERSION=4.0.2
-ENV MAVEN_VERSION=3.5.4
+ENV TOOLS_DIR=/opt/security-tools
  
-RUN mkdir -p /opt/security-tools
-
-RUN curl --create-dirs -sSLo /opt/security-tools/apache-maven-${MAVEN_VERSION}.tar.gz http://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz
-# -- Install Maven
-RUN tar xzf /opt/security-tools/apache-maven-${MAVEN_VERSION}.tar.gz
-RUN ln -s /opt/security-tools/apache-maven-${MAVEN_VERSION} /opt/maven
-RUN ln -s /opt/maven/bin/mvn /usr/local/bin
-RUN rm -f /opt/security-tools/apache-maven-${MAVEN_VERSION}.tar.gz
-ENV MAVEN_HOME /opt/maven
+RUN mkdir -p $TOOLS_DIR
 
 # -- Install SpotBugs with FindSecBugs plugin
-RUN curl --create-dirs -sSLo /opt/security-tools/spotbugs.zip http://central.maven.org/maven2/com/github/spotbugs/spotbugs/${SPOTBUGS_VERSION}/spotbugs-${SPOTBUGS_VERSION}.zip
-RUN unzip /opt/security-tools/spotbugs.zip
- 
-RUN curl --create-dirs -sSLo /opt/security-tools/spotbugs-${SPOTBUGS_VERSION}/plugin/findsecbugs-plugin.jar  http://central.maven.org/maven2/com/h3xstream/findsecbugs/findsecbugs-plugin/1.8.0/findsecbugs-plugin-1.8.0.jar
+RUN curl -sSL http://central.maven.org/maven2/com/github/spotbugs/spotbugs/${SPOTBUGS_VERSION}/spotbugs-${SPOTBUGS_VERSION}.tgz | tar -zxf - -C $TOOLS_DIR \
+ && curl --create-dirs -sSLo /opt/security-tools/spotbugs-${SPOTBUGS_VERSION}/plugin/findsecbugs-plugin.jar http://central.maven.org/maven2/com/h3xstream/findsecbugs/findsecbugs-plugin/1.8.0/findsecbugs-plugin-1.8.0.jar
  
 # -- Install OWASP Depdendency check
- 
-RUN curl --create-dirs -sSLo /opt/security-tools/dependency-check.zip  https://dl.bintray.com/jeremy-long/owasp/dependency-check-${DEPCHECK_VERSION}-release.zip
-RUN unzip /opt/security-tools/dependency-check.zip
- 
-# -- Remove downloaded zip files
-RUN rm -f /opt/security-tools/spotbugs.zip  /opt/security-tools/dependency-check.zip
-# -- set agent version an workdir
-RUN chmod -R 777 /opt/security-tools
-RUN chown -R jenkins /opt/security-tools
-RUN ls -la /opt/security-tools/dependency-check
+RUN cd $TOOLS_DIR \
+ && curl -sSLO https://dl.bintray.com/jeremy-long/owasp/dependency-check-${DEPCHECK_VERSION}-release.zip \
+ && unzip dependency-check-${DEPCHECK_VERSION}-release.zip \
+ && rm -f dependency-check-${DEPCHECK_VERSION}-release.zip
 
 # -- as jenkins user
 USER jenkins

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,6 @@ ENV DEPCHECK_VERSION=4.0.2
 ENV MAVEN_VERSION=3.5.4
  
 RUN mkdir -p /opt/security-tools
-WORKDIR /opt/security-tools
 
 RUN curl --create-dirs -sSLo /opt/security-tools/apache-maven-${MAVEN_VERSION}.tar.gz http://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz
 # -- Install Maven

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,29 @@
-FROM ubuntu:16.04
+FROM jenkins/slave
 MAINTAINER Adrian Bienkowski
 
+# -- copy start up script
+COPY jenkins-slave /usr/local/bin/jenkins-slave
+
+USER root
+
 # -- install build essentials and tools
-RUN apt-get update -qqy \
- && apt-get -qqy --no-install-recommends install \
+RUN apt update -qqy \
+ && apt upgrade -qqy \
+ && apt -qqy install \
     build-essential \
     ca-certificates \
     clang \
-    curl openssh-client openssl \
+    curl \
     git \
     jq \
     less \
     libxml2-utils \
-    openjdk-8-jdk \
+    openssh-client \
+    openssl \
     python \
     rsync \
     tzdata \
-	unzip \
+	  unzip \
  && rm -rf /var/lib/apt/lists/*
 
 # -- Install security tools
@@ -27,9 +34,7 @@ ENV MAVEN_VERSION=3.5.4
 RUN mkdir -p /opt/security-tools
 WORKDIR /opt/security-tools
 
-# -- Get Maven
 RUN curl --create-dirs -sSLo /opt/security-tools/apache-maven-${MAVEN_VERSION}.tar.gz http://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz
-
 # -- Install Maven
 RUN tar xzf /opt/security-tools/apache-maven-${MAVEN_VERSION}.tar.gz
 RUN ln -s /opt/security-tools/apache-maven-${MAVEN_VERSION} /opt/maven
@@ -50,39 +55,13 @@ RUN unzip /opt/security-tools/dependency-check.zip
  
 # -- Remove downloaded zip files
 RUN rm -f /opt/security-tools/spotbugs.zip  /opt/security-tools/dependency-check.zip
-
-
 # -- set agent version an workdir
-ARG VERSION=3.14
-ARG AGENT_WORKDIR=/home/jenkins/agent
-
-# -- install slave jar
-RUN curl --create-dirs -sSLo /usr/share/jenkins/slave.jar https://repo.jenkins-ci.org/public/org/jenkins-ci/main/remoting/${VERSION}/remoting-${VERSION}.jar \
-  && chmod 755 /usr/share/jenkins \
-  && chmod 644 /usr/share/jenkins/slave.jar
-
-# -- copy start up script
-COPY jenkins-slave /usr/local/bin/jenkins-slave
-
-# -- create jenkins user and home directory
-ENV HOME /home/jenkins
-RUN groupadd -g 10000 jenkins \
- && useradd -u 10000 -m -g jenkins jenkins
-
 RUN chmod -R 777 /opt/security-tools
 RUN chown -R jenkins /opt/security-tools
 RUN ls -la /opt/security-tools/dependency-check
 
 # -- as jenkins user
 USER jenkins
-ENV AGENT_WORKDIR=${AGENT_WORKDIR}
-RUN mkdir /home/jenkins/.jenkins \
- && mkdir -p /home/jenkins/.ssh \
- && mkdir -p /home/jenkins/.m2 \
- && mkdir -p ${AGENT_WORKDIR}
- 
-# -- set working directory for the container
-WORKDIR /home/jenkins
 
 # -- set entrypoint for the container
 ENTRYPOINT ["/usr/local/bin/jenkins-slave"]

--- a/jenkins-slave
+++ b/jenkins-slave
@@ -28,7 +28,6 @@
 # * JENKINS_URL : alternate jenkins URL
 # * JENKINS_SECRET : agent secret, if not set as an argument
 # * JENKINS_AGENT_NAME : agent name, if not set as an argument
-# * JENKINS_AGENT_WORKDIR : agent work directory, if not set by optional parameter -workDir
 
 if [ $# -eq 1 ]; then
 
@@ -37,7 +36,7 @@ if [ $# -eq 1 ]; then
 
 else
 
-	# if -tunnel is not provided, try env vars
+	# if -tunnel is not provided try env vars
 	case "$@" in
 		*"-tunnel "*) ;;
 		*)
@@ -45,15 +44,6 @@ else
 			TUNNEL="-tunnel $JENKINS_TUNNEL"
 		fi ;;
 	esac
-
-	# if -workDir is not provided, try env vars
-	if [ ! -z "$JENKINS_AGENT_WORKDIR" ]; then
-		case "$@" in
-			*"-workDir"*) echo "Warning: Work directory is defined twice in command-line arguments and the environment variable" ;;
-			*)
-			WORKDIR="-workDir $JENKINS_AGENT_WORKDIR" ;;
-		esac
-	fi
 
 	if [ -n "$JENKINS_URL" ]; then
 		URL="-url $JENKINS_URL"
@@ -68,13 +58,7 @@ else
 		JNLP_PROTOCOL_OPTS="-Dorg.jenkinsci.remoting.engine.JnlpProtocol3.disabled=true"
 	fi
 
-	# if java home is defined, use it
-	JAVA_BIN="java"
-	if [ "$JAVA_HOME" ]; then
-		JAVA_BIN="$JAVA_HOME/bin/java"
-	fi
-
-	# if both required options are defined, do not pass the parameters
+	# If both required options are defined, do not pass the parameters
 	OPT_JENKINS_SECRET=""
 	if [ -n "$JENKINS_SECRET" ]; then
 		case "$@" in
@@ -96,5 +80,5 @@ else
 	#TODO: Handle the case when the command-line and Environment variable contain different values.
 	#It is fine it blows up for now since it should lead to an error anyway.
 
-	exec $JAVA_BIN $JAVA_OPTS $JNLP_PROTOCOL_OPTS -cp /usr/share/jenkins/slave.jar hudson.remoting.jnlp.Main -headless $TUNNEL $URL $WORKDIR $OPT_JENKINS_SECRET $OPT_JENKINS_AGENT_NAME "$@"
+	exec java $JAVA_OPTS $JNLP_PROTOCOL_OPTS -cp /usr/share/jenkins/slave.jar hudson.remoting.jnlp.Main -headless $TUNNEL $URL $OPT_JENKINS_SECRET $OPT_JENKINS_AGENT_NAME "$@"
 fi

--- a/jenkins-slave
+++ b/jenkins-slave
@@ -28,6 +28,7 @@
 # * JENKINS_URL : alternate jenkins URL
 # * JENKINS_SECRET : agent secret, if not set as an argument
 # * JENKINS_AGENT_NAME : agent name, if not set as an argument
+# * JENKINS_AGENT_WORKDIR : agent work directory, if not set by optional parameter -workDir
 
 if [ $# -eq 1 ]; then
 
@@ -36,7 +37,7 @@ if [ $# -eq 1 ]; then
 
 else
 
-	# if -tunnel is not provided try env vars
+	# if -tunnel is not provided, try env vars
 	case "$@" in
 		*"-tunnel "*) ;;
 		*)
@@ -44,6 +45,15 @@ else
 			TUNNEL="-tunnel $JENKINS_TUNNEL"
 		fi ;;
 	esac
+
+	# if -workDir is not provided, try env vars
+	if [ ! -z "$JENKINS_AGENT_WORKDIR" ]; then
+		case "$@" in
+			*"-workDir"*) echo "Warning: Work directory is defined twice in command-line arguments and the environment variable" ;;
+			*)
+			WORKDIR="-workDir $JENKINS_AGENT_WORKDIR" ;;
+		esac
+	fi
 
 	if [ -n "$JENKINS_URL" ]; then
 		URL="-url $JENKINS_URL"
@@ -58,7 +68,13 @@ else
 		JNLP_PROTOCOL_OPTS="-Dorg.jenkinsci.remoting.engine.JnlpProtocol3.disabled=true"
 	fi
 
-	# If both required options are defined, do not pass the parameters
+	# if java home is defined, use it
+	JAVA_BIN="java"
+	if [ "$JAVA_HOME" ]; then
+		JAVA_BIN="$JAVA_HOME/bin/java"
+	fi
+
+	# if both required options are defined, do not pass the parameters
 	OPT_JENKINS_SECRET=""
 	if [ -n "$JENKINS_SECRET" ]; then
 		case "$@" in
@@ -80,5 +96,5 @@ else
 	#TODO: Handle the case when the command-line and Environment variable contain different values.
 	#It is fine it blows up for now since it should lead to an error anyway.
 
-	exec java $JAVA_OPTS $JNLP_PROTOCOL_OPTS -cp /usr/share/jenkins/slave.jar hudson.remoting.jnlp.Main -headless $TUNNEL $URL $OPT_JENKINS_SECRET $OPT_JENKINS_AGENT_NAME "$@"
+	exec $JAVA_BIN $JAVA_OPTS $JNLP_PROTOCOL_OPTS -cp /usr/share/jenkins/slave.jar hudson.remoting.jnlp.Main -headless $TUNNEL $URL $WORKDIR $OPT_JENKINS_SECRET $OPT_JENKINS_AGENT_NAME "$@"
 fi


### PR DESCRIPTION
It's built and you can test it using test tag.

https://cloud.docker.com/repository/docker/abienkowski/jnlp-slave/builds

I'll span up this version slave-test.